### PR TITLE
feat(systemd*): include systemd config files from /usr/lib/systemd

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -42,6 +42,8 @@ install() {
         "$systemdutildir"/system-generators/systemd-debug-generator \
         "$systemdutildir"/system-generators/systemd-fstab-generator \
         "$systemdutildir"/system-generators/systemd-gpt-auto-generator \
+        "$systemdutildir"/system.conf \
+        "$systemdutildir"/system.conf.d/*.conf \
         "$systemdsystemunitdir"/debug-shell.service \
         "$systemdsystemunitdir"/cryptsetup.target \
         "$systemdsystemunitdir"/cryptsetup-pre.target \
@@ -94,8 +96,8 @@ install() {
 
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
-            /etc/systemd/system.conf \
-            /etc/systemd/system.conf.d/*.conf \
+            "$systemdutilconfdir"/system.conf \
+            "$systemdutilconfdir"/system.conf.d/*.conf \
             /etc/hosts \
             /etc/hostname \
             /etc/nsswitch.conf \

--- a/modules.d/01systemd-coredump/module-setup.sh
+++ b/modules.d/01systemd-coredump/module-setup.sh
@@ -33,6 +33,7 @@ install() {
     inst_multiple -o \
         "$sysctld"/50-coredump.conf \
         "$systemdutildir"/coredump.conf \
+        "$systemdutildir/coredump.conf.d/*.conf" \
         "$systemdutildir"/systemd-coredump \
         "$systemdsystemunitdir"/systemd-coredump.socket \
         "$systemdsystemunitdir"/systemd-coredump@.service \
@@ -51,7 +52,7 @@ install() {
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
             "$systemdutilconfdir"/coredump.conf \
-            "$systemdsystemconfdir/coredump.conf.d/*.conf" \
+            "$systemdutilconfdir/coredump.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-coredump.socket \
             "$systemdsystemconfdir/systemd-coredump.socket.d/*.conf" \
             "$systemdsystemconfdir"/systemd-coredump@.service \

--- a/modules.d/01systemd-pstore/module-setup.sh
+++ b/modules.d/01systemd-pstore/module-setup.sh
@@ -34,6 +34,8 @@ install() {
     inst_dir /var/lib/systemd/pstore
     inst_multiple -o \
         "$tmpfilesdir/systemd-pstore.conf" \
+        "$systemdutildir"/pstore.conf \
+        "$systemdutildir/pstore.conf.d/*.conf" \
         "$systemdutildir"/systemd-pstore \
         "$systemdsystemunitdir"/systemd-pstore.service \
         "$systemdsystemunitdir/systemd-pstore.service.d/*.conf"

--- a/modules.d/01systemd-resolved/module-setup.sh
+++ b/modules.d/01systemd-resolved/module-setup.sh
@@ -49,6 +49,7 @@ install() {
     # Install the hosts local user configurations if enabled.
     if [[ $hostonly ]]; then
         inst_multiple -H -o \
+            "$systemdutilconfdir"/resolv.conf \
             "$systemdutilconfdir"/resolved.conf \
             "$systemdutilconfdir/resolved.conf.d/*.conf" \
             "$systemdsystemconfdir"/systemd-resolved.service \

--- a/modules.d/01systemd-timesyncd/module-setup.sh
+++ b/modules.d/01systemd-timesyncd/module-setup.sh
@@ -38,6 +38,7 @@ install() {
         "$systemdntpunits/*.list" \
         "$systemdutildir"/systemd-timesyncd \
         "$systemdutildir"/systemd-time-wait-sync \
+        "$systemdutildir"/timesyncd.conf \
         "$systemdutildir/timesyncd.conf.d/*.conf" \
         "$systemdsystemunitdir"/systemd-timesyncd.service \
         "$systemdsystemunitdir/systemd-timesyncd.service.d/*.conf" \


### PR DESCRIPTION
and also use proper variables for the paths.

--

The new systemd reads from both /etc and /usr/, so to accomodate this, I've added new paths to install configs from (I probably haven't covered all). This changes only hostonly behaviour; uses global variables:

systemdutilconfdir: "/etc/systemd"
systemdutildir: "/lib/systemd:/lib/systemd/systemd-udevd" "/usr/lib/systemd:/usr/lib/systemd/systemd-udevd"

(Cherry-picked commit: fcb66b03b34b6afd0f599bbe910d4a5fbc31bcbf from PR#511)

Resolves: RHEL-32506