### PR TITLE
CI & container fixes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -62,35 +62,6 @@ jobs:
                 uses: actions/checkout@v4
             -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
                 run: USE_NETWORK=${{ matrix.network }} ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
-    network-legacy:
-        name: ${{ matrix.test }} on ${{ matrix.container }} using ${{ matrix.network }}
-        runs-on: ubuntu-latest
-        timeout-minutes: 45
-        concurrency:
-            group: network-legacy-${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.network }}
-            cancel-in-progress: true
-        strategy:
-            matrix:
-                container: [
-                        "centos:stream10",
-                ]
-                network: [
-                        "network-legacy",
-                ]
-                test: [
-                        "20",
-                        "30",
-                        "40",
-                ]
-            fail-fast: false
-        container:
-            image: ghcr.io/redhat-plumbers/${{ matrix.container }}
-            options: "--privileged -v /dev:/dev"
-        steps:
-            -   name: "Checkout Repository"
-                uses: actions/checkout@v4
-            -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
-                run: USE_NETWORK=${{ matrix.network }} ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
     systemd-networkd:
         name: ${{ matrix.test }} on ${{ matrix.container }} using ${{ matrix.network }}
         runs-on: ubuntu-latest

--- a/.packit.yml
+++ b/.packit.yml
@@ -9,6 +9,7 @@ patch_generation_ignore_paths:
 - .distro/
 - .packit.yml
 - .github/
+- test/
 patch_generation_patch_id_digits: 1
 sync_changelog: true
 

--- a/test/container/Dockerfile-CentOS-10-Stream
+++ b/test/container/Dockerfile-CentOS-10-Stream
@@ -9,8 +9,8 @@ RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)'
 
 # Install needed packages for the dracut CI container
 # FIXME: properly re-add dash once C10S EPEL is available
-#    http://mirrors.kernel.org/fedora/releases/34/Everything/x86_64/os/Packages/d/dash-0.5.10.2-8.fc34.x86_64.rpm \
 RUN dnf -y install --skip-broken --enablerepo crb --setopt=install_weak_deps=False \
+    https://kojipkgs.fedoraproject.org//packages/dash/0.5.12/4.eln141/x86_64/dash-0.5.12-4.eln141.x86_64.rpm \
     qemu-kvm \
     NetworkManager \
     asciidoc \


### PR DESCRIPTION
rhel-only

_ _ _ _

`dash` package in Fedora: https://koji.fedoraproject.org/koji/packageinfo?packageID=5242