### PR TITLE
fix(dracut-functions): allow for \ in get_maj_min file path

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -243,7 +243,7 @@ get_maj_min() {
     local _out
 
     if [[ $get_maj_min_cache_file ]]; then
-        _out="$(grep -m1 -oE "^$1 \S+$" "$get_maj_min_cache_file" | awk '{print $NF}')"
+        _out="$(grep -m1 -oE "^${1//\\/\\\\} \S+$" "$get_maj_min_cache_file" | awk '{print $NF}')"
     fi
 
     if ! [[ "$_out" ]]; then


### PR DESCRIPTION
as the path might be f.e. /dev/disk/by-partlabel/EFI\x20System\x20Partition

which would produce Warning 'grep: warning: stray \ before x' in get_maj_min

Resolves: RHEL-47145
