### PR TITLE
CI & test fixes

### DIFF
--- a/modules.d/80test-makeroot/module-setup.sh
+++ b/modules.d/80test-makeroot/module-setup.sh
@@ -6,7 +6,7 @@ check() {
 }
 
 depends() {
-    echo "dash rootfs-block kernel-modules qemu"
+    echo "rootfs-block kernel-modules qemu"
 }
 
 installkernel() {

--- a/test/TEST-16-DMSQUASH/test.sh
+++ b/test/TEST-16-DMSQUASH/test.sh
@@ -128,14 +128,18 @@ SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"
 EOF
 
     test_dracut \
-        --modules "dash dmsquash-live qemu" \
+        --no-hostonly \
+        --add "dmsquash-live qemu" \
+        --omit "systemd" \
         --drivers "ntfs3" \
         --install "mkfs.ext4" \
         --include /tmp/ntfs3.rules /lib/udev/rules.d/ntfs3.rules \
         "$TESTDIR"/initramfs.testing
 
     test_dracut \
-        --modules "dmsquash-live-autooverlay qemu" \
+        --no-hostonly \
+        --add "dmsquash-live-autooverlay qemu" \
+        --omit "systemd" \
         --install "mkfs.ext4" \
         "$TESTDIR"/initramfs.testing-autooverlay
 

--- a/test/TEST-20-NFS/test.sh
+++ b/test/TEST-20-NFS/test.sh
@@ -402,6 +402,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         -a "dmsquash-live ${USE_NETWORK}" \
         "$TESTDIR"/initramfs.testing
 

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -213,7 +213,7 @@ test_setup() {
 
     # Make server's dracut image
     "$DRACUT" -l \
-        -a "dash rootfs-block test kernel-modules network-legacy" \
+        -a "rootfs-block test kernel-modules ${USE_NETWORK}" \
         -d "piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg virtio_pci virtio_scsi" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i ./wait-if-server.sh /lib/dracut/hooks/pre-mount/99-wait-if-server.sh \

--- a/test/TEST-30-ISCSI/test.sh
+++ b/test/TEST-30-ISCSI/test.sh
@@ -222,6 +222,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         --add "$USE_NETWORK" \
         --include "./client.link" "/etc/systemd/network/01-client.link" \
         --kernel-cmdline "rw rd.auto rd.retry=50" \

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -227,6 +227,7 @@ test_setup() {
 
     # Make client's dracut image
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         --add "$USE_NETWORK" \
         -i "./client.link" "/etc/systemd/network/01-client.link" \
         "$TESTDIR"/initramfs.testing

--- a/test/TEST-35-ISCSI-MULTI/test.sh
+++ b/test/TEST-35-ISCSI-MULTI/test.sh
@@ -234,7 +234,7 @@ test_setup() {
 
     # Make server's dracut image
     "$DRACUT" -l -i "$TESTDIR"/overlay / \
-        -a "test dash rootfs-block debug kernel-modules network-legacy" \
+        -a "test rootfs-block debug kernel-modules ${USE_NETWORK}" \
         -d "af_packet piix ide-gd_mod ata_piix ext4 sd_mod e1000 drbg" \
         -i "./server.link" "/etc/systemd/network/01-server.link" \
         -i "./wait-if-server.sh" "/lib/dracut/hooks/pre-mount/99-wait-if-server.sh" \

--- a/test/TEST-40-NBD/test.sh
+++ b/test/TEST-40-NBD/test.sh
@@ -332,6 +332,7 @@ test_setup() {
     echo -n test > /tmp/key
 
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         -a "${USE_NETWORK}" \
         -i "./cryptroot-ask.sh" "/sbin/cryptroot-ask" \
         -i "./client.link" "/etc/systemd/network/01-client.link" \

--- a/test/TEST-50-MULTINIC/test.sh
+++ b/test/TEST-50-MULTINIC/test.sh
@@ -341,6 +341,7 @@ test_setup() {
     )
     # Make client's dracut image
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         -a "${USE_NETWORK}" \
         "$TESTDIR"/initramfs.testing
 

--- a/test/TEST-60-BONDBRIDGEVLAN/test.sh
+++ b/test/TEST-60-BONDBRIDGEVLAN/test.sh
@@ -367,6 +367,7 @@ test_setup() {
     )
     # Make client's dracut image
     test_dracut \
+        --no-hostonly --no-hostonly-cmdline \
         -a "debug ${USE_NETWORK} ifcfg" \
         "$TESTDIR"/initramfs.testing
 

--- a/test/container/Dockerfile-CentOS-10-Stream
+++ b/test/container/Dockerfile-CentOS-10-Stream
@@ -121,3 +121,9 @@ RUN dnf -y install --skip-broken --setopt=install_weak_deps=False \
     wget \
     xz \
     && dnf -y remove dracut --noautoremove && dnf -y update && dnf clean all
+
+# discard configurations that enforce an out-of-tree dracut module
+# which would break test automation
+# since this is a distro specific change, lets do it in the container
+RUN \
+  rm -rf /usr/lib/dracut/dracut.conf.d/50-nss-softokn.conf

--- a/test/container/Dockerfile-CentOS-10-Stream
+++ b/test/container/Dockerfile-CentOS-10-Stream
@@ -11,6 +11,7 @@ RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)'
 # FIXME: properly re-add dash once C10S EPEL is available
 RUN dnf -y install --skip-broken --enablerepo crb --setopt=install_weak_deps=False \
     https://kojipkgs.fedoraproject.org//packages/dash/0.5.12/4.eln141/x86_64/dash-0.5.12-4.eln141.x86_64.rpm \
+    https://kojipkgs.fedoraproject.org//packages/btrfs-progs/6.9.2/1.eln141/x86_64/btrfs-progs-6.9.2-1.eln141.x86_64.rpm \
     qemu-kvm \
     NetworkManager \
     asciidoc \

--- a/test/test-functions
+++ b/test/test-functions
@@ -20,7 +20,7 @@ DRACUT=${DRACUT-${basedir}/dracut.sh}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
 test_dracut() {
-    TEST_DRACUT_ARGS+=" --local --no-hostonly --no-hostonly-cmdline --no-early-microcode --add test --force --kver $KVERSION"
+    TEST_DRACUT_ARGS+=" --local --no-early-microcode --add test --force --kver $KVERSION"
 
     # include $TESTDIR"/overlay if exists
     if [ -d "$TESTDIR"/overlay ]; then

--- a/test/test-functions
+++ b/test/test-functions
@@ -20,7 +20,16 @@ DRACUT=${DRACUT-${basedir}/dracut.sh}
 PKGLIBDIR=${PKGLIBDIR-$basedir}
 
 test_dracut() {
-    TEST_DRACUT_ARGS+=" --local --no-early-microcode --add test --force --kver $KVERSION"
+    # directory for test configurations
+    mkdir -p /tmp/dracut.conf.d
+
+    # grab the distro configuration from the host and make it available for the tests
+    if [ -d /usr/lib/dracut/dracut.conf.d ]; then
+        cp -a /usr/lib/dracut/dracut.conf.d /tmp/
+    fi
+
+    # pick up configuration from /tmp/dracut.conf.d when running the tests
+    TEST_DRACUT_ARGS+=" --local --confdir /tmp/dracut.conf.d --no-early-microcode --add test --force --kver $KVERSION"
 
     # include $TESTDIR"/overlay if exists
     if [ -d "$TESTDIR"/overlay ]; then


### PR DESCRIPTION
- test: do not force no-hostonly for all test runs
- test: grab the distro configuration from the host and make it available
- test: do not force include dash, let sh module make a selection
- ci: remove dracut native config that is not compatible with upstream ci
- ci: add btrfs-progs to container file
