### PR TITLE
feat(dracut-init.sh): give --force-add precedence over --omit

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -960,8 +960,10 @@ check_module() {
     [[ $2 ]] || mods_checked_as_dep+=" $_mod "
 
     if [[ " $omit_dracutmodules " == *\ $_mod\ * ]]; then
-        ddebug "Module '$_mod' will not be installed, because it's in the list to be omitted!"
-        return 1
+        if [[ " $force_add_dracutmodules " != *\ $_mod\ * ]]; then
+            ddebug "Module '$_mod' will not be installed, because it's in the list to be omitted!"
+            return 1
+        fi
     fi
 
     if [[ " $dracutmodules $add_dracutmodules $force_add_dracutmodules" == *\ $_mod\ * ]]; then


### PR DESCRIPTION
This gives precedence of force_add_dracutmodules to omit_dracutmodules,
as there is not other way to override omit_dracutmodules list, and users
would expect it to be overriden from command line.

Ref: https://github.com/dracut-ng/dracut-ng/pull/569

This way, `--add` retains it behaviour, and `--force-add` gains additional
functionality in non-hostonly mode. The module may still be skipped
if the module check returns 1, but it should throw error (as I'd expect
for `--force-add`).

(cherry picked commit a669346f48cbb3278c51ba5e95b1b91f9bfdee0a from PR#584)

Resolves: RHEL-53791
