### PR TITLE
feat(lsinitrd.sh): look for initrd in /usr/lib/modules/

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -136,6 +136,8 @@ else
         image="/lib/modules/${KERNEL_VERSION}/initramfs.img"
     elif [[ -f /boot/initramfs-${KERNEL_VERSION}.img ]]; then
         image="/boot/initramfs-${KERNEL_VERSION}.img"
+    elif [[ -f /usr/lib/modules/${KERNEL_VERSION}/initramfs.img ]]; then
+        image="/usr/lib/modules/${KERNEL_VERSION}/initramfs.img"
     elif [[ $MACHINE_ID ]] \
         && mountpoint -q /efi; then
         image="/efi/${MACHINE_ID}/${KERNEL_VERSION}/initrd"


### PR DESCRIPTION
Introduce new path for lsinitrd.sh to look into:

/usr/lib/modules/$kver/initramfs.img

Which is valid on all ostree-based systems, and also other image based
systems with pre-generated initramfs.

Ref: https://issues.redhat.com/browse/RHEL-35890
(cherry picked from commit 22ae6ecaf9ecdb9db3e79aa9a72d527e7436c282)

Resolves: RHEL-54650
