### PR TITLE
Revert "fix(base): do not require chroot inside initramfs"

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -9,6 +9,7 @@ depends() {
 # called by dracut
 install() {
     inst_multiple \
+        chroot \
         cp \
         dmesg \
         flock \


### PR DESCRIPTION
This reverts commit 518133714b769160448a51c512d5e152ea6332da.

Resolves: RHEL-93173
