### PR TITLE
fix(qemu): add missing bochs module explicitly

### DIFF
--- a/.distro/dracut.spec
+++ b/.distro/dracut.spec
@@ -152,7 +152,7 @@ in a squashfs image, result in a smaller initramfs size and reduce runtime memor
 usage.
 
 %prep
-%autosetup -n %{name}-ng-%{version} -S git_am
+%autosetup -n %{name}-%{version} -S git_am
 cp %{SOURCE1} .
 
 %build

--- a/modules.d/90qemu/module-setup.sh
+++ b/modules.d/90qemu/module-setup.sh
@@ -21,4 +21,7 @@ installkernel() {
         spapr-vscsi \
         qemu_fw_cfg \
         efi_secret
+
+    # needed for displaying console properly
+    hostonly='' instmods bochs
 }


### PR DESCRIPTION
As it is needed to display console properly, and doesn't get detected in some cases.
