### PR TITLE
rhel 10 fix 210943

### DIFF
--- a/.distro/dracut.spec
+++ b/.distro/dracut.spec
@@ -445,6 +445,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %changelog
 * Tue Jul 28 2026 Pavel Valena <pvalena@redhat.com> - 107-10
 - fix(base): escape die() message in emergency hook script
+- fix(base): replace eval with safe variable indirection in splitsep and export_n
 
 * Thu Jul 02 2026 Pavel Valena <pvalena@redhat.com> - 107-9
 - fix(i18n): prefer 'simpledrm' over 'drm' module

--- a/.distro/dracut.spec
+++ b/.distro/dracut.spec
@@ -8,7 +8,7 @@
 
 Name: dracut
 Version: 107
-Release: 9%{?dist}
+Release: 10%{?dist}
 
 Summary: Initramfs generator using udev
 
@@ -443,6 +443,9 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{_prefix}/lib/kernel/install.d/51-dracut-rescue.install
 
 %changelog
+* Tue Jul 28 2026 Pavel Valena <pvalena@redhat.com> - 107-10
+- fix(base): escape die() message in emergency hook script
+
 * Thu Jul 02 2026 Pavel Valena <pvalena@redhat.com> - 107-9
 - fix(i18n): prefer 'simpledrm' over 'drm' module
 

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -410,7 +410,8 @@ die() {
     } > /dev/kmsg
 
     {
-        echo "warn dracut: FATAL: \"$*\""
+        printf 'warn dracut: FATAL: %q\n' "$*"
+
         echo "warn dracut: Refusing to continue"
     } >> $hookdir/emergency/01-die.sh
     [ -d /run/initramfs ] || mkdir -p -- /run/initramfs

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -329,12 +329,18 @@ splitsep() {
 
     while [ -n "$str" ] && [ "$#" -gt 1 ]; do
         tmp="${str%%"$sep"*}"
-        eval "$1='${tmp}'"
+        local -n _splitsep_ref="$1"
+        _splitsep_ref="$tmp"
+        unset -n _splitsep_ref
         str="${str#"$tmp"}"
         str="${str#"$sep"}"
         shift
     done
-    [ -n "$str" ] && [ -n "$1" ] && eval "$1='$str'"
+    if [ -n "$str" -a -n "$1" ]; then
+        local -n _splitsep_ref="$1"
+        _splitsep_ref="$str"
+        unset -n _splitsep_ref
+    fi
     debug_on
     return 0
 }
@@ -923,14 +929,13 @@ emergency_shell() {
 }
 
 # Retain the values of these variables but ensure that they are unexported
-# This is a POSIX-compliant equivalent of bash's "export -n"
 export_n() {
     local var
     local val
     for var in "$@"; do
-        eval "val=\$$var"
+        val="${!var}"
         unset "$var"
-        [ -n "$val" ] && eval "$var=\"$val\""
+        [ -n "$val" ] && printf -v "$var" '%s' "$val"
     done
 }
 


### PR DESCRIPTION
- **fix(base): escape die() message in emergency hook script**
- **fix(base): replace eval with safe variable indirection in splitsep and export_n**
