### PR TITLE
fix(dracut): remove trailing null characters from SBATs when building UKIs

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2556,6 +2556,7 @@ get_sbat_string() {
     local inp=$1
     local out=$uefi_outdir/$2
     objcopy -O binary --only-section=.sbat "$inp" "$out"
+    sed -i 's/\x00*$//' "$out"
     clean_sbat_string "$out"
 }
 


### PR DESCRIPTION
SBAT of kernel has null character paddings at the end. Using tools
like ukify will display massive amount of '\0' in SBAT. Ukify is
doing ".rstrip('b\x00')" when merging SBATs.

(cherry picked from commit cbe71b639522c3f328d2a1757a3c54214df66b31)

Resolves: RHEL-214163
